### PR TITLE
Correcting php-excel usage example in README

### DIFF
--- a/README
+++ b/README
@@ -40,7 +40,7 @@ to the browser (for downloading):
 <?php
 
 require 'php-excel.class.php';
-$mydata = array(1 => 'Oliver Schwarz', 'Friedhelm Hasematzel');
+$mydata = array(array(1 => 'Oliver Schwarz', 'Friedhelm Hasematzel'));
 $xls = new Excel_XML;
 $xls->addWorksheet('My data', $mydata);
 $xls->sendWorkbook('mydata.xls');


### PR DESCRIPTION
Corrects php-excel usage example in README, as long php-excel library only accepts multidimensional arrays as parameter value to add data to Excel file. The previous example was using a simple array and caused errors in Excel file generation.
